### PR TITLE
fix: update terraform provider versions to more recent iterations

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The following permissions are required to run this module:
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.6 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.6 |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/cos/versions.tf
+++ b/cos/versions.tf
@@ -2,9 +2,9 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.50.0"
+      version = "~>1.59"
     }
   }
 
-  required_version = ">= 1.2.6"
+  required_version = ">= 1.4.6"
 }

--- a/toolchain/versions.tf
+++ b/toolchain/versions.tf
@@ -2,13 +2,13 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.50.0"
+      version = "~>1.59"
     }
     gitlab = {
       source = "gitlabhq/gitlab"
-      version = "3.15.1"
+      version = "16.3.0"
     }
   }
 
-  required_version = ">= 1.2.6"
+  required_version = ">= 1.4.6"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,13 +2,13 @@ terraform {
   required_providers {
     ibm = {
       source = "IBM-Cloud/ibm"
-      version = "1.50.0"
+      version = "~>1.59"
     }
     gitlab = {
       source = "gitlabhq/gitlab"
-      version = "3.15.1"
+      version = "16.3.0"
     }
   }
 
-  required_version = ">= 1.2.6"
+  required_version = ">= 1.4.6"
 }


### PR DESCRIPTION
### Description

Updates the versioning of the terraform providers required for this deployable architecture.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content
Bumps the version of the IBM and GitLab terraform providers for the Static Website deployable architecture.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
